### PR TITLE
Adds functionality and bind for toggling the minimap in-game

### DIFF
--- a/DQXI-SDK/CustomActions.cpp
+++ b/DQXI-SDK/CustomActions.cpp
@@ -4,6 +4,8 @@
 // For adding to this file, see list of hookable SetupInputComponent funcs at https://gist.github.com/emoose/61be532af247f486902103096da5d38f
 // (indented funcs call into the non-indented func above it, so only that needs hooking to affect all its indented children)
 
+bool minimapEnabled = true;
+
 bool IsPlayerMovementEnabled(AActor* actor)
 {
   auto player = g_StaticFuncs->STATIC_GetJackGamePlayer(actor);
@@ -33,6 +35,7 @@ void FirstPersonCamera(AJackFieldPlayerController* playerController)
     return; 
 
   IsFirstPerson = !IsFirstPerson; //toggle first person
+  minimapEnabled = !minimapEnabled; //toggle minimap variable (just keeping track)
   if (Options.FirstPersonMovable)
   {
     if (Options.HideMinimap)
@@ -42,6 +45,12 @@ void FirstPersonCamera(AJackFieldPlayerController* playerController)
   }
 
   playerController->Camera(IsFirstPerson ? CamStyle_FirstPersonView : CamStyle_Normal);
+}
+
+void ToggleMinimap(AJackFieldPlayerController* playerController)
+{
+  minimapEnabled = !minimapEnabled;
+  g_JackCheatManager->SetMiniMapVisible(!IsFirstPerson);
 }
 
 void EnterPartyChat(AJackFieldPlayerController* playerController)

--- a/DQXI-SDK/CustomActions.cpp
+++ b/DQXI-SDK/CustomActions.cpp
@@ -92,6 +92,8 @@ void Init_CustomActions_Field(AJackFieldPlayerController* playerController)
   input->BindAction("EnterNakamaKaiwa", EInputEvent::IE_Pressed, playerController, EnterPartyChat);
 
   input->BindAction("QuitGame", EInputEvent::IE_Pressed, (AActor*)playerController, QuitGame);
+  
+  input->BindAction("ToggleMinimap", EInputEvent::IE_Pressed, playerController, ToggleMinimap);
 }
 
 void Init_CustomActions_UI(AActor* Actor, UInputComponent* PlayerInputComponent)

--- a/DQXI-SDK/CustomActions.cpp
+++ b/DQXI-SDK/CustomActions.cpp
@@ -50,7 +50,7 @@ void FirstPersonCamera(AJackFieldPlayerController* playerController)
 void ToggleMinimap(AJackFieldPlayerController* playerController)
 {
   minimapEnabled = !minimapEnabled;
-  g_JackCheatManager->SetMiniMapVisible(!IsFirstPerson);
+  g_JackCheatManager->SetMiniMapVisible(minimapEnabled);
 }
 
 void EnterPartyChat(AJackFieldPlayerController* playerController)

--- a/Input.ini
+++ b/Input.ini
@@ -160,10 +160,10 @@ AxisMappings=(AxisName="Turn",Key=K,Scale=1.f)
 AxisMappings=(AxisName="Turn",Key=Gamepad_RightX,Scale=-1.f)
 AxisMappings=(AxisName="Turn",Key=Semicolon,Scale=-1.f)
 AxisMappings=(AxisName="TurnMouse",Key=MouseX,Scale=-1.f,bDebugOnly=True)
-AxisMappings=(AxisName="UILeftX",Key=Gamepad_LeftX,Scale=1.f)
+;AxisMappings=(AxisName="UILeftX",Key=Gamepad_LeftX,Scale=1.f) ;commenting out -- this will prevent the left stick from advancing dialog. D-Pad can still be used for this, in theory
 AxisMappings=(AxisName="UILeftX",Key=D,Scale=1.f)
 AxisMappings=(AxisName="UILeftX",Key=A,Scale=-1.f)
-AxisMappings=(AxisName="UILeftY",Key=Gamepad_LeftY,Scale=1.f)
+;AxisMappings=(AxisName="UILeftY",Key=Gamepad_LeftY,Scale=1.f) ;commenting out -- this will prevent the left stick from advancing dialog. D-Pad can still be used for this, in theory
 AxisMappings=(AxisName="UILeftY",Key=W,Scale=1.f)
 AxisMappings=(AxisName="UILeftY",Key=S,Scale=-1.f)
 AxisMappings=(AxisName="UIRightX",Key=K,Scale=-1.f)

--- a/Input.ini
+++ b/Input.ini
@@ -18,6 +18,8 @@ ActionMappings=(ActionName="FirstPersonCamera", Key=MiddleMouseButton)
 ActionMappings=(ActionName="FirstPersonCamera", Key=Gamepad_Special_Left)
 ActionMappings=(ActionName="EnterPartyChat", Key=Gamepad_LeftThumbstick)
 
+ActionMappings=(ActionName="ToggleMinimap", Key=K)
+
 ; Default game bindings
 ; Gamepad_FaceButton refers to the A/B/X/Y (X/Circle/Square/Triangle) on your gamepad, the direction decides which button
 ActionMappings=(ActionName="Action",Key=Gamepad_FaceButton_Bottom)

--- a/Input.ini
+++ b/Input.ini
@@ -18,7 +18,7 @@ ActionMappings=(ActionName="FirstPersonCamera", Key=MiddleMouseButton)
 ActionMappings=(ActionName="FirstPersonCamera", Key=Gamepad_Special_Left)
 ActionMappings=(ActionName="EnterPartyChat", Key=Gamepad_LeftThumbstick)
 
-ActionMappings=(ActionName="ToggleMinimap", Key=K)
+ActionMappings=(ActionName="ToggleMinimap", Key=J)
 
 ; Default game bindings
 ; Gamepad_FaceButton refers to the A/B/X/Y (X/Circle/Square/Triangle) on your gamepad, the direction decides which button


### PR DESCRIPTION
This seems to be a common request: apparently a lot of folks have some strong hatred for the minimap (mostly unnecessary or clutters the UI, I guess?). This just adds a bind to toggle it easily in-game. 

I had actually made these changes awhile back and been testing on it since, no major issues found or reported back to me (ShockedHearts being the only other one i'm aware of using this fork) -- decided to finally submit a pull request when I realized I had forgotten about it for nearly a month